### PR TITLE
Avoid panicking on unexported fields

### DIFF
--- a/asset/data.go
+++ b/asset/data.go
@@ -89,6 +89,11 @@ func splitBySubtype(data any) map[api.DataSubtype]map[string]interface{} {
 
 	for i := 0; i < valueType.NumField(); i++ {
 		field := valueType.Field(i)
+
+		if field.PkgPath != "" {
+			// Skip unexported fields.
+			continue
+		}
 		fieldValue := value.Field(i).Interface()
 
 		tag, ok := ParseElionaTag(field)


### PR DESCRIPTION
The method Interface() cannot be called on unexported fields.